### PR TITLE
fix bug: filename with spaces

### DIFF
--- a/lib/docx2gfm.rb
+++ b/lib/docx2gfm.rb
@@ -32,6 +32,10 @@ module Docx2gfm
           puts opts
           exit
         end
+        opts.on('-v', '--version', 'Show version of docx2gfm') do
+          puts Docx2gfm::VERSION
+          exit
+        end
       end
 
       # most useful way of creating a required parameter with OptionParser

--- a/lib/docx2gfm/docx_gfm_converter.rb
+++ b/lib/docx2gfm/docx_gfm_converter.rb
@@ -6,12 +6,12 @@ class DocxGfmConverter
   end
 
   # perform all conversation and cleanup steps
-  def process_gfm()
-    docx_2_gfm(@options[:file])
-    cleanup_content_gfm()
-    create_ref_style_links() if @options[:ref_style_links]
-    add_frontmatter() if @options[:jekyll]
-  end
+  # def process_gfm()
+  #   docx_2_gfm(@options[:file])
+  #   cleanup_content_gfm()
+  #   create_ref_style_links() if @options[:ref_style_links]
+  #   add_frontmatter() if @options[:jekyll]
+  # end
 
   def process_markdown()
     docx_2_markdown(@options[:file])
@@ -26,16 +26,16 @@ class DocxGfmConverter
   end
 
   # convert docx to initial markdown
-  def docx_2_gfm(file)
-    # TODO before reading the file, I could check if the file exists
-    # TODO check out pandoc options that might be useful e.g. --extract-media='/images/own/'
-    @content = `pandoc #{file} -f docx -t gfm --wrap=none`
-  end
+  # def docx_2_gfm(file)
+  #   # TODO before reading the file, I could check if the file exists
+  #   # TODO check out pandoc options that might be useful e.g. --extract-media='/images/own/'
+  #   @content = `pandoc #{file} -f docx -t gfm --wrap=none`
+  # end
 
   def docx_2_markdown(file)
     # TODO before reading the file, I could check if the file exists
     # TODO check out pandoc options that might be useful e.g. --extract-media='/images/own/'
-    @content = `pandoc #{file} --wrap=none --atx-headers -f docx -t markdown-bracketed_spans-link_attributes-smart-simple_tables -s`
+    @content = `pandoc '#{file}' --wrap=none --atx-headers -f docx -t markdown-bracketed_spans-link_attributes-smart-simple_tables -s`
   end
 
   # this removes all sorts of strange stuff that pandoc generates when

--- a/lib/docx2gfm/version.rb
+++ b/lib/docx2gfm/version.rb
@@ -1,3 +1,3 @@
 module Docx2gfm
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
Fixs #15 

- Add option to list version number in the CLI
- Quote .docx filename when passing it along to pandoc. (Fixes #15). Also commenting out unused code.
